### PR TITLE
V2.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,10 @@ else()
 endif()
 
 #add_executable(${TARGET} fclip.cpp pch.cpp)
-add_executable(${TARGET} src/fclip.cpp src/pch.cpp)
+add_executable(${TARGET} src/fclip.cpp src/pch.cpp src/LastError.cpp)
 
 configure_file(src/pch.h.in pch.h)
-target_include_directories(${TARGET} PUBLIC "${PROJECT_BINARY_DIR}")
+target_include_directories(${TARGET} PUBLIC "${PROJECT_BINARY_DIR}" src)
 
 target_link_libraries(${TARGET} -static)
 target_link_libraries(${TARGET} Ole32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 set(TARGET fileclip CACHE STRING "The projects name." FORCE)
 
-project(${TARGET} VERSION 2.2.0)
+project(${TARGET} VERSION 2.3.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/README.md
+++ b/README.md
@@ -108,12 +108,29 @@ OS Version:                10.0.19041 N/A Build 19041
 
 # Installation
 
+## Path Environment
+
+By default `%LOCALAPPDATA%\Microsoft\WindowsApps` should be available within your
+`PATH` environment variable. So copying `fileclip.exe` to this location should enough.
+
+```
+> copy fileclip.exe %LOCALAPPDATA%\Microsoft\WindowsApps
+    1 file(s) copied.
+
+> where fileclip
+C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\fileclip.exe
+```
+
+> The `fileclip.exe` should placed within one directory of the `%PATH%` environment
+> variable or the `PATH` variable needs to be extended with the directory where `fileclip.exe`
+> resides.
+
 ## Registry
 
 https://learn.microsoft.com/en-us/windows/win32/shell/app-registration
 
 - HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths
-- HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths ???
+- HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths
 
 ## CMake
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fclip v2.1
+# fclip
 
 In reference to the windows `clip` the ~~`fclip`~~ (see [Changes](#changes)) `fileclip` command copies files to the windows clipboard or pastes them from it.
 
@@ -37,10 +37,19 @@ Press `ctrl + v` to paste the files.
 
 ## Pasting
 
-    fileclip -v
+```
+> fileclip -v
+```
 
 `fileclip -v` checks if the clipboard contains a file reference and pastes it to
 the current location. It simulates pressing `ctrl + v`.
+
+## Version
+
+```
+> fileclip
+fileclip Version 2.2.0
+```
 
 # Changes
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ fileclip Version 2.2.0
 
 # Changes
 
+- v2.3
+	- Change(s):
+		- Display usage information when starting `fileclip` without parameter.
+		- Keep console window open when executing `fileclip` via the explorer (e.g. double-click).
+		- Display last error on stderr if copying fails.
+		- Error message in english only.
+	- Develop:
+		- LastError class to facilitate message retrieval of `GetLastError` error codes.
 - v2.2
 	- Bug(s)
 		- Fallback to paste by CF_HDROP if FILECONTENTS is not available.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ OS Name:                   Microsoft Windows 10 Enterprise
 OS Version:                10.0.19041 N/A Build 19041
 ```
 
+# Installation
+
+## Registry
+
+https://learn.microsoft.com/en-us/windows/win32/shell/app-registration
+
+- HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths
+- HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths ???
+
 ## CMake
 
 Example configuration and compilation assuming `g++` (MinGW-w64) is installed.

--- a/src/LastError.cpp
+++ b/src/LastError.cpp
@@ -1,4 +1,103 @@
 #include "LastError.h"
+
+
+LastError LastError::New()
+{
+    return New(GetLastError());
+}
+
+LastError LastError::New(DWORD lastErrorCode)
+{
+    return LastError{lastErrorCode};
+}
+
+
+LastError::LastError() : LastError{GetLastError()}
+{
+    DBGPRINT(L"Default c'tor.");
+}
+
+LastError::LastError(DWORD lastErrorCode) : _lastErrorCode{lastErrorCode}, _lastErrorMessage{nullptr}
+{
+    DBGPRINT(L"C'tor(lastErrorCode := %d)", _lastErrorCode);
+    setLastErrorMessage();
+}
+
+LastError::~LastError()
+{
+    DBGPRINT(L"Destructor");
+    resetLastErrorMessage();
+}
+
+LastError::LastError(const LastError& other) : LastError{other._lastErrorCode}
+{
+    DBGPRINT(L"Copy c'tor");
+}
+
+LastError::LastError(LastError&& other) noexcept
+    : _lastErrorCode(std::exchange(other._lastErrorCode, 0)),
+        _lastErrorMessage(std::exchange(other._lastErrorMessage, nullptr))
+{
+    DBGPRINT(L"Move c'tor");
+}
+
+
+LastError& LastError::operator=(const LastError& other)
+{
+    DBGPRINT(L"copy assignment");
+    if (this == &other)
+        return *this;
+
+    _lastErrorCode = other._lastErrorCode;
+    setLastErrorMessage();
+
+    return *this;
+}
+
+LastError& LastError::operator=(LastError&& other) noexcept
+{
+    DBGPRINT(L"move assignment");
+    std::swap(_lastErrorCode, other._lastErrorCode);
+    std::swap(_lastErrorMessage, other._lastErrorMessage);
+    return *this;
+}
+
+LPCWSTR LastError::c_str() const
+{
+    return _lastErrorMessage;
+}
+
+DWORD LastError::getLastError() const
+{
+    return _lastErrorCode;
+}
+
+void LastError::resetLastErrorMessage()
+{
+    if (_lastErrorMessage != nullptr) {
+        LocalFree(_lastErrorMessage);
+        _lastErrorMessage = nullptr;
+    }
+}
+
+void LastError::setLastErrorMessage()
+{
+    resetLastErrorMessage();
+    DWORD msgLength = FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        _lastErrorCode,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        (LPWSTR)&_lastErrorMessage,
+        0,
+        NULL
+    );
+    // remove cr lf
+    _lastErrorMessage[msgLength - 2] = '\0';
+}
+
+
+
 std::wostream& operator<<(std::wostream& os, const LastError& error)
 {
 	os << error._lastErrorMessage;

--- a/src/LastError.cpp
+++ b/src/LastError.cpp
@@ -1,4 +1,98 @@
-#include "LastError.h"
+#include "pch.h"
+
+LastError LastError::New()
+{
+    return New(GetLastError());
+}
+
+LastError LastError::New(DWORD lastErrorCode)
+{
+    return LastError{lastErrorCode};
+}
+
+LastError::LastError() : LastError{GetLastError()}
+{
+    DBGPRINT(L"Default c'tor.");
+}
+
+LastError::LastError(DWORD lastErrorCode) : _lastErrorCode{lastErrorCode}, _lastErrorMessage{nullptr}
+{
+    DBGPRINT(L"C'tor(lastErrorCode := %d)", _lastErrorCode);
+    setLastErrorMessage();
+}
+
+LastError::~LastError()
+{
+    DBGPRINT(L"Destructor");
+    resetLastErrorMessage();
+}
+
+LastError::LastError(const LastError& other) : LastError{other._lastErrorCode}
+{
+    DBGPRINT(L"Copy c'tor");
+}
+
+LastError::LastError(LastError&& other) noexcept
+    : _lastErrorCode(std::exchange(other._lastErrorCode, 0)),
+        _lastErrorMessage(std::exchange(other._lastErrorMessage, nullptr))
+{
+    DBGPRINT(L"Move c'tor");
+}
+
+LastError& LastError::operator=(const LastError& other)
+{
+    DBGPRINT(L"copy assignment");
+    if (this == &other)
+        return *this;
+
+    _lastErrorCode = other._lastErrorCode;
+    setLastErrorMessage();
+
+    return *this;
+}
+
+LastError& LastError::operator=(LastError&& other) noexcept
+{
+    DBGPRINT(L"move assignment");
+    std::swap(_lastErrorCode, other._lastErrorCode);
+    std::swap(_lastErrorMessage, other._lastErrorMessage);
+    return *this;
+}
+
+LPCWSTR LastError::c_str() const
+{
+    return _lastErrorMessage;
+}
+
+DWORD LastError::getLastError() const
+{
+    return _lastErrorCode;
+}
+
+void LastError::resetLastErrorMessage()
+{
+    if (_lastErrorMessage != nullptr) {
+        LocalFree(_lastErrorMessage);
+        _lastErrorMessage = nullptr;
+    }
+}
+
+void LastError::setLastErrorMessage()
+{
+    resetLastErrorMessage();
+    DWORD msgLength = FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        _lastErrorCode,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        (LPWSTR)&_lastErrorMessage,
+        0,
+        NULL
+    );
+    // remove cr lf
+    _lastErrorMessage[msgLength - 2] = '\0';
+}
+
 std::wostream& operator<<(std::wostream& os, const LastError& error)
 {
 	os << error._lastErrorMessage;

--- a/src/LastError.cpp
+++ b/src/LastError.cpp
@@ -95,6 +95,6 @@ void LastError::setLastErrorMessage()
 
 std::wostream& operator<<(std::wostream& os, const LastError& error)
 {
-	os << error._lastErrorMessage;
+	os << "[0x" << std::hex << error._lastErrorCode << "] " << error._lastErrorMessage;
 	return os;
 }

--- a/src/LastError.cpp
+++ b/src/LastError.cpp
@@ -1,0 +1,6 @@
+#include "LastError.h"
+std::wostream& operator<<(std::wostream& os, const LastError& error)
+{
+	os << error._lastErrorMessage;
+	return os;
+}

--- a/src/LastError.cpp
+++ b/src/LastError.cpp
@@ -84,7 +84,7 @@ void LastError::setLastErrorMessage()
         FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
         NULL,
         _lastErrorCode,
-        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
         (LPWSTR)&_lastErrorMessage,
         0,
         NULL

--- a/src/LastError.h
+++ b/src/LastError.h
@@ -46,7 +46,7 @@ public:
      * 
      * @sa https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
      * 
-     * @param lastErrorCode On of the [system error codes](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
+     * @param lastErrorCode One of the [system error codes](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
      */
 	LastError(DWORD lastErrorCode);
     /**

--- a/src/LastError.h
+++ b/src/LastError.h
@@ -1,3 +1,5 @@
+#pragma once
+#include "pch.h"
 class LastError
 {
 public:
@@ -195,8 +197,3 @@ private:
      */
 	friend std::wostream& operator<<(std::wostream& os, const LastError& error);
 };
-std::wostream& operator<<(std::wostream& os, const LastError& error)
-{
-	os << error._lastErrorMessage;
-	return os;
-}

--- a/src/LastError.h
+++ b/src/LastError.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "pch.h"
+
 class LastError
 {
 public:
@@ -13,10 +13,7 @@ public:
      * 
      * @return New LastError object
      */
-	static LastError New()
-	{
-		return New(GetLastError());
-	}
+	static LastError New();
     /**
      * @brief Creates a new LastError object.
      * 
@@ -27,10 +24,7 @@ public:
      * @param lastErrorCode On of the [system error codes](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
      * @return New LastError object
      */
-	static LastError New(DWORD lastErrorCode)
-	{
-		return LastError{lastErrorCode};
-	}
+	static LastError New(DWORD lastErrorCode);
 private:
 	/// @brief The system error code perceived during creation.
 	DWORD _lastErrorCode;
@@ -44,10 +38,7 @@ public:
      * by the `GetLastError` Win API function.
      * 
      */
-	LastError() : LastError{GetLastError()}
-	{
-		DBGPRINT(L"Default c'tor.");
-	}
+	LastError();
     /**
      * @brief Construct a new Last Error object
      * 
@@ -57,40 +48,24 @@ public:
      * 
      * @param lastErrorCode On of the [system error codes](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
      */
-	LastError(DWORD lastErrorCode) : _lastErrorCode{lastErrorCode}, _lastErrorMessage{nullptr}
-	{
-		DBGPRINT(L"C'tor(lastErrorCode := %d)", _lastErrorCode);
-		setLastErrorMessage();
-	}
+	LastError(DWORD lastErrorCode);
     /**
      * @brief Destroy the Last Error object
      * 
      */
-	~LastError()
-	{
-		DBGPRINT(L"Destructor");
-		resetLastErrorMessage();
-	}
+	~LastError();
 	/**
 	 * @brief Construct a new LastError object by copying from another
 	 * 
 	 * @param other The object which gets copied.
 	 */
-	LastError(const LastError& other) : LastError{other._lastErrorCode}
-	{
-		DBGPRINT(L"Copy c'tor");
-	}
+	LastError(const LastError& other);
 	/**
 	 * @brief Move C'tor semantics
 	 * 
 	 * @param other The object to move from.
 	 */
-	LastError(LastError&& other) noexcept
-		: _lastErrorCode(std::exchange(other._lastErrorCode, 0)),
-    	  _lastErrorMessage(std::exchange(other._lastErrorMessage, nullptr))
-	{
-		DBGPRINT(L"Move c'tor");
-	}
+	LastError(LastError&& other) noexcept;
 
 	/**
 	 * @brief Copy assignment operator.
@@ -98,30 +73,14 @@ public:
 	 * @param other The object which gets copied.
 	 * @return LastError& The copy.
 	 */
-    LastError& operator=(const LastError& other)
-    {
-		DBGPRINT(L"copy assignment");
-        if (this == &other)
-            return *this;
- 
-        _lastErrorCode = other._lastErrorCode;
-		setLastErrorMessage();
- 
-        return *this;
-    }
+    LastError& operator=(const LastError& other);
 	/**
 	 * @brief Move assignment operator.
 	 * 
 	 * @param other The object to move from.
 	 * @return LastError& The moved object.
 	 */
-	LastError& operator=(LastError&& other) noexcept
-    {
-		DBGPRINT(L"move assignment");
-        std::swap(_lastErrorCode, other._lastErrorCode);
-        std::swap(_lastErrorMessage, other._lastErrorMessage);
-        return *this;
-    }
+	LastError& operator=(LastError&& other) noexcept;
     /**
      * @brief Returns the null-terminated current error message.
      * 
@@ -130,19 +89,13 @@ public:
      * 
      * @return LPCWSTR The const pointer to the current error message.
      */
-	LPCWSTR c_str() const
-	{
-		return _lastErrorMessage;
-	}
+	LPCWSTR c_str() const;
     /**
      * @brief Returns the system error code perceived during creation.
      * 
      * @return DWORD The system [system error code](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
      */
-	DWORD getLastError() const
-	{
-		return _lastErrorCode;
-	}
+	DWORD getLastError() const;
 private:
     /**
      * @brief Sets `_lastErrorMessage` back to its original state (`nullptr`).
@@ -154,13 +107,7 @@ private:
      *       [Rule of five](https://en.cppreference.com/w/cpp/language/rule_of_three#Rule_of_five).
      * 
      */
-	void resetLastErrorMessage()
-	{
-		if (_lastErrorMessage != nullptr) {
-			LocalFree(_lastErrorMessage);
-			_lastErrorMessage = nullptr;
-		}
-	}
+	void resetLastErrorMessage();
     /**
      * @brief Set `_lastErrorMessage` according to the current `_lastErrorCode`.
      * 
@@ -169,21 +116,7 @@ private:
      * in `_lastErrorCode`.
      * 
      */
-	void setLastErrorMessage()
-	{
-		resetLastErrorMessage();
-		DWORD msgLength = FormatMessage(
-			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL,
-			_lastErrorCode,
-			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-			(LPWSTR)&_lastErrorMessage,
-			0,
-			NULL
-		);
-		// remove cr lf
-		_lastErrorMessage[msgLength - 2] = '\0';
-	}
+	void setLastErrorMessage();
     /**
      * @brief Stream operator to use with (UTF-16) output stream.
      * 

--- a/src/LastError.h
+++ b/src/LastError.h
@@ -1,0 +1,202 @@
+class LastError
+{
+public:
+    /**
+     * @brief Creates a new LastError object.
+     * 
+     * The new LastError object is created with the latest error code received
+     * by the `GetLastError` Win API function.
+     * 
+     * @sa https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+     * 
+     * @return New LastError object
+     */
+	static LastError New()
+	{
+		return New(GetLastError());
+	}
+    /**
+     * @brief Creates a new LastError object.
+     * 
+     * The new LastError object is created by submitting an system error code.
+     * 
+     * @sa https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes
+     * 
+     * @param lastErrorCode On of the [system error codes](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
+     * @return New LastError object
+     */
+	static LastError New(DWORD lastErrorCode)
+	{
+		return LastError{lastErrorCode};
+	}
+private:
+	/// @brief The system error code perceived during creation.
+	DWORD _lastErrorCode;
+	/// @brief The error string for the system error code.
+	LPWSTR _lastErrorMessage;
+public:
+    /**
+     * @brief Construct a new Last Error object.
+     * 
+     * The new LastError object is created with the latest error code received
+     * by the `GetLastError` Win API function.
+     * 
+     */
+	LastError() : LastError{GetLastError()}
+	{
+		DBGPRINT(L"Default c'tor.");
+	}
+    /**
+     * @brief Construct a new Last Error object
+     * 
+     * The new LastError object is created by submitting an system error code.
+     * 
+     * @sa https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+     * 
+     * @param lastErrorCode On of the [system error codes](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
+     */
+	LastError(DWORD lastErrorCode) : _lastErrorCode{lastErrorCode}, _lastErrorMessage{nullptr}
+	{
+		DBGPRINT(L"C'tor(lastErrorCode := %d)", _lastErrorCode);
+		setLastErrorMessage();
+	}
+    /**
+     * @brief Destroy the Last Error object
+     * 
+     */
+	~LastError()
+	{
+		DBGPRINT(L"Destructor");
+		resetLastErrorMessage();
+	}
+	/**
+	 * @brief Construct a new LastError object by copying from another
+	 * 
+	 * @param other The object which gets copied.
+	 */
+	LastError(const LastError& other) : LastError{other._lastErrorCode}
+	{
+		DBGPRINT(L"Copy c'tor");
+	}
+	/**
+	 * @brief Move C'tor semantics
+	 * 
+	 * @param other The object to move from.
+	 */
+	LastError(LastError&& other) noexcept
+		: _lastErrorCode(std::exchange(other._lastErrorCode, 0)),
+    	  _lastErrorMessage(std::exchange(other._lastErrorMessage, nullptr))
+	{
+		DBGPRINT(L"Move c'tor");
+	}
+
+	/**
+	 * @brief Copy assignment operator.
+	 * 
+	 * @param other The object which gets copied.
+	 * @return LastError& The copy.
+	 */
+    LastError& operator=(const LastError& other)
+    {
+		DBGPRINT(L"copy assignment");
+        if (this == &other)
+            return *this;
+ 
+        _lastErrorCode = other._lastErrorCode;
+		setLastErrorMessage();
+ 
+        return *this;
+    }
+	/**
+	 * @brief Move assignment operator.
+	 * 
+	 * @param other The object to move from.
+	 * @return LastError& The moved object.
+	 */
+	LastError& operator=(LastError&& other) noexcept
+    {
+		DBGPRINT(L"move assignment");
+        std::swap(_lastErrorCode, other._lastErrorCode);
+        std::swap(_lastErrorMessage, other._lastErrorMessage);
+        return *this;
+    }
+    /**
+     * @brief Returns the null-terminated current error message.
+     * 
+     * Returns a pointer to an array that contains a null-terminated sequence
+     * of characters representing the current error message.
+     * 
+     * @return LPCWSTR The const pointer to the current error message.
+     */
+	LPCWSTR c_str() const
+	{
+		return _lastErrorMessage;
+	}
+    /**
+     * @brief Returns the system error code perceived during creation.
+     * 
+     * @return DWORD The system [system error code](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
+     */
+	DWORD getLastError() const
+	{
+		return _lastErrorCode;
+	}
+private:
+    /**
+     * @brief Sets `_lastErrorMessage` back to its original state (`nullptr`).
+     * 
+     * Resets the `_lastErrorMessage` to nullptr and frees its occupied memory
+     * if necessary.
+     * 
+     * @note The method is used to prevent redundant code within the
+     *       [Rule of five](https://en.cppreference.com/w/cpp/language/rule_of_three#Rule_of_five).
+     * 
+     */
+	void resetLastErrorMessage()
+	{
+		if (_lastErrorMessage != nullptr) {
+			LocalFree(_lastErrorMessage);
+			_lastErrorMessage = nullptr;
+		}
+	}
+    /**
+     * @brief Set `_lastErrorMessage` according to the current `_lastErrorCode`.
+     * 
+     * If necessary `_lastErrorMessage` is reset (see resetLastErrorMessage())
+     * before allocating the new error string for the system error code stored
+     * in `_lastErrorCode`.
+     * 
+     */
+	void setLastErrorMessage()
+	{
+		resetLastErrorMessage();
+		DWORD msgLength = FormatMessage(
+			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL,
+			_lastErrorCode,
+			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+			(LPWSTR)&_lastErrorMessage,
+			0,
+			NULL
+		);
+		// remove cr lf
+		_lastErrorMessage[msgLength - 2] = '\0';
+	}
+    /**
+     * @brief Stream operator to use with (UTF-16) output stream.
+     * 
+     * Stream operator so a LastError object can be used in output streams.
+     * The error message gets submitted to the stream which is equivalent
+     * to the message received by c_str().
+     * 
+     * @param os    the (UTF-16) ouptut stream
+     * @param error the LastError object to submit to the stream.
+     * @return      std::wostream& the altered output stream.
+     */
+	friend std::wostream& operator<<(std::wostream& os, const LastError& error);
+};
+std::wostream& operator<<(std::wostream& os, const LastError& error)
+{
+	os << error._lastErrorMessage;
+	return os;
+}

--- a/src/LastError.h
+++ b/src/LastError.h
@@ -13,10 +13,7 @@ public:
      * 
      * @return New LastError object
      */
-	static LastError New()
-	{
-		return New(GetLastError());
-	}
+	static LastError New();
     /**
      * @brief Creates a new LastError object.
      * 
@@ -27,10 +24,7 @@ public:
      * @param lastErrorCode On of the [system error codes](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
      * @return New LastError object
      */
-	static LastError New(DWORD lastErrorCode)
-	{
-		return LastError{lastErrorCode};
-	}
+	static LastError New(DWORD lastErrorCode);
 private:
 	/// @brief The system error code perceived during creation.
 	DWORD _lastErrorCode;
@@ -44,10 +38,7 @@ public:
      * by the `GetLastError` Win API function.
      * 
      */
-	LastError() : LastError{GetLastError()}
-	{
-		DBGPRINT(L"Default c'tor.");
-	}
+	LastError();
     /**
      * @brief Construct a new Last Error object
      * 
@@ -57,40 +48,24 @@ public:
      * 
      * @param lastErrorCode On of the [system error codes](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
      */
-	LastError(DWORD lastErrorCode) : _lastErrorCode{lastErrorCode}, _lastErrorMessage{nullptr}
-	{
-		DBGPRINT(L"C'tor(lastErrorCode := %d)", _lastErrorCode);
-		setLastErrorMessage();
-	}
+	LastError(DWORD lastErrorCode);
     /**
      * @brief Destroy the Last Error object
      * 
      */
-	~LastError()
-	{
-		DBGPRINT(L"Destructor");
-		resetLastErrorMessage();
-	}
+	~LastError();
 	/**
 	 * @brief Construct a new LastError object by copying from another
 	 * 
 	 * @param other The object which gets copied.
 	 */
-	LastError(const LastError& other) : LastError{other._lastErrorCode}
-	{
-		DBGPRINT(L"Copy c'tor");
-	}
+	LastError(const LastError& other);
 	/**
 	 * @brief Move C'tor semantics
 	 * 
 	 * @param other The object to move from.
 	 */
-	LastError(LastError&& other) noexcept
-		: _lastErrorCode(std::exchange(other._lastErrorCode, 0)),
-    	  _lastErrorMessage(std::exchange(other._lastErrorMessage, nullptr))
-	{
-		DBGPRINT(L"Move c'tor");
-	}
+	LastError(LastError&& other) noexcept;
 
 	/**
 	 * @brief Copy assignment operator.
@@ -98,30 +73,14 @@ public:
 	 * @param other The object which gets copied.
 	 * @return LastError& The copy.
 	 */
-    LastError& operator=(const LastError& other)
-    {
-		DBGPRINT(L"copy assignment");
-        if (this == &other)
-            return *this;
- 
-        _lastErrorCode = other._lastErrorCode;
-		setLastErrorMessage();
- 
-        return *this;
-    }
+    LastError& operator=(const LastError& other);
 	/**
 	 * @brief Move assignment operator.
 	 * 
 	 * @param other The object to move from.
 	 * @return LastError& The moved object.
 	 */
-	LastError& operator=(LastError&& other) noexcept
-    {
-		DBGPRINT(L"move assignment");
-        std::swap(_lastErrorCode, other._lastErrorCode);
-        std::swap(_lastErrorMessage, other._lastErrorMessage);
-        return *this;
-    }
+	LastError& operator=(LastError&& other) noexcept;
     /**
      * @brief Returns the null-terminated current error message.
      * 
@@ -130,19 +89,13 @@ public:
      * 
      * @return LPCWSTR The const pointer to the current error message.
      */
-	LPCWSTR c_str() const
-	{
-		return _lastErrorMessage;
-	}
+	LPCWSTR c_str() const;
     /**
      * @brief Returns the system error code perceived during creation.
      * 
      * @return DWORD The system [system error code](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes)
      */
-	DWORD getLastError() const
-	{
-		return _lastErrorCode;
-	}
+	DWORD getLastError() const;
 private:
     /**
      * @brief Sets `_lastErrorMessage` back to its original state (`nullptr`).
@@ -154,13 +107,7 @@ private:
      *       [Rule of five](https://en.cppreference.com/w/cpp/language/rule_of_three#Rule_of_five).
      * 
      */
-	void resetLastErrorMessage()
-	{
-		if (_lastErrorMessage != nullptr) {
-			LocalFree(_lastErrorMessage);
-			_lastErrorMessage = nullptr;
-		}
-	}
+	void resetLastErrorMessage();
     /**
      * @brief Set `_lastErrorMessage` according to the current `_lastErrorCode`.
      * 
@@ -169,21 +116,7 @@ private:
      * in `_lastErrorCode`.
      * 
      */
-	void setLastErrorMessage()
-	{
-		resetLastErrorMessage();
-		DWORD msgLength = FormatMessage(
-			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL,
-			_lastErrorCode,
-			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-			(LPWSTR)&_lastErrorMessage,
-			0,
-			NULL
-		);
-		// remove cr lf
-		_lastErrorMessage[msgLength - 2] = '\0';
-	}
+	void setLastErrorMessage();
     /**
      * @brief Stream operator to use with (UTF-16) output stream.
      * 

--- a/src/fclip.cpp
+++ b/src/fclip.cpp
@@ -54,11 +54,16 @@ void printClipboardFormats();
  */
 int main(int argc, char** /*argv*/)
 {
+	DWORD procId; DWORD processCount = GetConsoleProcessList(&procId, 1);	
 	DBGPRINT(L"%S %s", VERSION, __DATE__ " " __TIME__);
 	LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);
 	if (argc == 1) {
 		std::filesystem::path exe = argv[0];
 		std::wcout << exe.stem().wstring() << L" Version " << VERSION << std::endl;
+		DBGPRINT(L"GetConsoleProcessList => %d", processCount);
+		if (processCount < 2) {
+			system("pause");
+		}
 		return 0;
 	}
 	// parse command line parameter

--- a/src/fclip.cpp
+++ b/src/fclip.cpp
@@ -98,7 +98,8 @@ public:
 	 * @param other 
 	 */
 	LastError(LastError&& other) noexcept
-    	: _lastErrorMessage(std::exchange(other._lastErrorMessage, nullptr))
+		: _lastErrorCode(std::exchange(other._lastErrorCode, 0)),
+    	  _lastErrorMessage(std::exchange(other._lastErrorMessage, nullptr))
 	{
 		DBGPRINT(L"Move c'tor");
 	}
@@ -115,7 +116,7 @@ public:
         if (this == &other)
             return *this;
  
-        _lastErrorMessage = other._lastErrorMessage;
+        _lastErrorCode = other._lastErrorCode;
 		setLastErrorMessage();
  
         return *this;
@@ -129,6 +130,7 @@ public:
 	LastError& operator=(LastError&& other) noexcept
     {
 		DBGPRINT(L"move assignment");
+        std::swap(_lastErrorCode, other._lastErrorCode);
         std::swap(_lastErrorMessage, other._lastErrorMessage);
         return *this;
     }
@@ -180,11 +182,11 @@ int main(int argc, char** /*argv*/)
 {
 	GetProcessId(NULL);
 	LastError err = LastError::New();
-	DBGPRINT("[%x]: %S", err.getLastError(), err.c_str());
+	DBGPRINT("[0x%x]: %S", err.getLastError(), err.c_str());
 
-	SetLastError(0);
+	SetLastError(255);
 	err = LastError::New();
-	DBGPRINT("[%x]: %S", err.getLastError(), err.c_str());
+	DBGPRINT("[0x%x]: %S", err.getLastError(), err.c_str());
 
 	DWORD procId; DWORD processCount = GetConsoleProcessList(&procId, 1);	
 	DBGPRINT(L"%S %s", VERSION, __DATE__ " " __TIME__);

--- a/src/fclip.cpp
+++ b/src/fclip.cpp
@@ -54,6 +54,119 @@ void pasteByFileContents(CLIPFORMAT clFileDescriptor, CLIPFORMAT clFileContents)
 void printClipboardFormats();
 #endif
 
+class LastError
+{
+public:
+	static LastError New()
+	{
+		return New(GetLastError());
+	}
+	static LastError New(DWORD lastErrorCode)
+	{
+		return LastError{lastErrorCode};
+	}
+private:
+	DWORD _lastErrorCode;
+	LPWSTR _lastErrorMessage;
+public:
+	LastError() : LastError{GetLastError()}
+	{
+		DBGPRINT(L"Default c'tor.");
+	}
+	LastError(DWORD lastErrorCode) : _lastErrorCode{lastErrorCode}, _lastErrorMessage{nullptr}
+	{
+		DBGPRINT(L"C'tor(lastErrorCode := %d)", _lastErrorCode);
+		setLastErrorMessage();
+	}
+	~LastError()
+	{
+		DBGPRINT(L"Destructor");
+		resetLastErrorMessage();
+	}
+	/**
+	 * @brief Construct a new LastError object by copying from another
+	 * 
+	 * @param other 
+	 */
+	LastError(const LastError& other) : LastError{other._lastErrorCode}
+	{
+		DBGPRINT(L"Copy c'tor");
+	}
+	/**
+	 * @brief Move C'tor semantics
+	 * 
+	 * @param other 
+	 */
+	LastError(LastError&& other) noexcept
+    	: _lastErrorMessage(std::exchange(other._lastErrorMessage, nullptr))
+	{
+		DBGPRINT(L"Move c'tor");
+	}
+
+	/**
+	 * @brief Copy assignment operator.
+	 * 
+	 * @param other 
+	 * @return LastError& 
+	 */
+    LastError& operator=(const LastError& other)
+    {
+		DBGPRINT(L"copy assignment");
+        if (this == &other)
+            return *this;
+ 
+        _lastErrorMessage = other._lastErrorMessage;
+		setLastErrorMessage();
+ 
+        return *this;
+    }
+	/**
+	 * @brief Move assignment operator.
+	 * 
+	 * @param other 
+	 * @return LastError& 
+	 */
+	LastError& operator=(LastError&& other) noexcept
+    {
+		DBGPRINT(L"move assignment");
+        std::swap(_lastErrorMessage, other._lastErrorMessage);
+        return *this;
+    }
+	LPCWSTR c_str() const
+	{
+		return _lastErrorMessage;
+	}
+private:
+	void resetLastErrorMessage()
+	{
+		if (_lastErrorMessage != nullptr) {
+			LocalFree(_lastErrorMessage);
+			_lastErrorMessage = nullptr;
+		}
+	}
+	void setLastErrorMessage()
+	{
+		resetLastErrorMessage();
+		DWORD msgLength = FormatMessage(
+			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL,
+			_lastErrorCode,
+			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+			(LPWSTR)&_lastErrorMessage,
+			0,
+			NULL
+		);
+		// remove cr lf
+		_lastErrorMessage[msgLength - 2] = '\0';
+	}
+	friend std::wostream& operator<<(std::wostream& os, const LastError& error);
+};
+std::wostream& operator<<(std::wostream& os, const LastError& error)
+{
+	os << error._lastErrorMessage;
+	return os;
+}
+
 /**
  * @brief The main entry point
  * 
@@ -61,6 +174,11 @@ void printClipboardFormats();
  */
 int main(int argc, char** /*argv*/)
 {
+	GetProcessId(NULL);
+	const auto& err = LastError::New();
+	DBGPRINT(L"%S", err.c_str());
+	std::wcout << err << std::endl;
+
 	DWORD procId; DWORD processCount = GetConsoleProcessList(&procId, 1);	
 	DBGPRINT(L"%S %s", VERSION, __DATE__ " " __TIME__);
 	LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);

--- a/src/fclip.cpp
+++ b/src/fclip.cpp
@@ -136,6 +136,10 @@ public:
 	{
 		return _lastErrorMessage;
 	}
+	DWORD getLastError() const
+	{
+		return _lastErrorCode;
+	}
 private:
 	void resetLastErrorMessage()
 	{
@@ -175,9 +179,12 @@ std::wostream& operator<<(std::wostream& os, const LastError& error)
 int main(int argc, char** /*argv*/)
 {
 	GetProcessId(NULL);
-	const auto& err = LastError::New();
-	DBGPRINT(L"%S", err.c_str());
-	std::wcout << err << std::endl;
+	LastError err = LastError::New();
+	DBGPRINT("[%x]: %S", err.getLastError(), err.c_str());
+
+	SetLastError(0);
+	err = LastError::New();
+	DBGPRINT("[%x]: %S", err.getLastError(), err.c_str());
 
 	DWORD procId; DWORD processCount = GetConsoleProcessList(&procId, 1);	
 	DBGPRINT(L"%S %s", VERSION, __DATE__ " " __TIME__);

--- a/src/fclip.cpp
+++ b/src/fclip.cpp
@@ -63,14 +63,6 @@ void printClipboardFormats();
  */
 int main(int argc, char** /*argv*/)
 {
-	GetProcessId(NULL);
-	LastError err = LastError::New();
-	DBGPRINT("[0x%x]: %S", err.getLastError(), err.c_str());
-
-	SetLastError(255);
-	err = LastError::New();
-	DBGPRINT("[0x%x]: %S", err.getLastError(), err.c_str());
-
 	DWORD procId; DWORD processCount = GetConsoleProcessList(&procId, 1);	
 	DBGPRINT(L"%S %s", VERSION, __DATE__ " " __TIME__);
 	LPWSTR* argv = CommandLineToArgvW(GetCommandLine(), &argc);

--- a/src/fclip.cpp
+++ b/src/fclip.cpp
@@ -11,6 +11,13 @@
 #include "pch.h" // Pre-compiled header
 
 /**
+ * @brief Pint usage information.
+ * 
+ * Displays usage information on the console.
+ * 
+ */
+void usage();
+/**
  * @brief Copy the files specified by the command line to the clipboard.
  * 
  * @param argc The command line argument count
@@ -60,8 +67,9 @@ int main(int argc, char** /*argv*/)
 	if (argc == 1) {
 		std::filesystem::path exe = argv[0];
 		std::wcout << exe.stem().wstring() << L" Version " << VERSION << std::endl;
+		usage();
 		DBGPRINT(L"GetConsoleProcessList => %d", processCount);
-		if (processCount < 2) {
+		if (processCount < 2) { // < 2 => GUI
 			system("pause");
 		}
 		return 0;
@@ -243,6 +251,22 @@ void pasteByFileContents(CLIPFORMAT clFileDescriptor, CLIPFORMAT clFileContents)
 		} while (read == ISTREAM_BUF_SIZE);
 		CloseHandle(hFile);
 	}
+}
+
+void usage()
+{
+	std::wcout << L"" << std::endl;
+	std::wcout << L"Copys files to the clipbard as if done by pressing <ctrl>+c" << std::endl;
+	std::wcout << L"or pastes files from the clipboard by copying them to the current location." << std::endl;
+	std::wcout << std::endl;
+	std::wcout << L"fileclip [-v | file1 [file2 [... [fileN]]]]" << std::endl;
+	std::wcout << std::endl;
+	std::wcout << L"-v        Paste files previously copyied to the cliboard into the current folder." << std::endl;
+	std::wcout << L"file1 ... The relative and/or absolute file paths to copy to the clipboard." << std::endl;
+	std::wcout << std::endl;
+	std::wcout << L"example:" << std::endl;
+	std::wcout << L"> fileclip -v" << std::endl;
+	std::wcout << L"> fileclip C:\\path\\to\\file1 file2 ..\\file3 \"folder\\file 4\"" << std::endl;
 }
 
 #ifdef DEBUG

--- a/src/fclip.cpp
+++ b/src/fclip.cpp
@@ -9,7 +9,6 @@
  * 
  */
 #include "pch.h" // Pre-compiled header
-#include "LastError.h"
 
 /**
  * @brief Pint usage information.

--- a/src/fclip.cpp
+++ b/src/fclip.cpp
@@ -109,8 +109,11 @@ int copy(int argc, wchar_t* argv[])
 		// path elements (e.g.: ..\..\file.dat might become C:\file.dat).
 		bufSizes[i - 1] = GetFullPathName(argv[i], bufSizes[i - 1], files[i - 1], NULL) + 1; // +1 => \0
 		DBGPRINT(L"(Re-)setting buffer size to %d", bufSizes[i - 1]);
-		if (GetFileAttributes(files[i - 1]) == INVALID_FILE_ATTRIBUTES)
+		if (GetFileAttributes(files[i - 1]) == INVALID_FILE_ATTRIBUTES) {
+			const auto& err = LastError::New();
+			std::wcerr << files[i - 1] << ": " << err << std::endl;
 			return INVALID_FILE_ATTRIBUTES;
+		}
 		// calculate *bytes* needed for memory allocation
 		clpSize += sizeof(wchar_t) * (bufSizes[i - 1]);
 		DBGPRINT(L"Added '%S' to buffer.", files[i - 1]);

--- a/src/pch.h.in
+++ b/src/pch.h.in
@@ -16,6 +16,7 @@
 // TODO: add headers that you want to pre-compile here
 #include <iostream>
 #include <filesystem>
+#include <utility>
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>

--- a/src/pch.h.in
+++ b/src/pch.h.in
@@ -23,6 +23,8 @@
 #include <Shlobj.h>   // DROPFILES
 #include <ShellApi.h> // CommandLineToArgvW()
 
+#include "LastError.h"
+
 #define VERSION L"@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@"
 
 #ifdef __GNUC__


### PR DESCRIPTION
# v2.3
- Change(s):
    - Display usage information when starting fileclip without parameter.
    - Keep console window open when executing fileclip via the explorer (e.g. double-click).
    - Display last error on stderr if copying fails.
    - Error message in english only.
- Develop:
    - LastError class to facilitate message retrieval of GetLastError error codes.

